### PR TITLE
Fix map pathGenerator references

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -6,7 +6,7 @@ const pathGenerator = d3.geoPath().projection(projection);
 
 svg.append('path')
     .attr('class', 'sphere')
-    .attr('d', d3.pathGenerator({type: 'Sphere'}))
+    .attr('d', pathGenerator({type: 'Sphere'}))
 
 d3.json('https://unpkg.com/world-atlas@1.1.4/world/110m.json')
     .then(data => {
@@ -14,5 +14,5 @@ d3.json('https://unpkg.com/world-atlas@1.1.4/world/110m.json')
     svg.selectAll('path').data(countries.features)
         .enter().append('path')
             .attr('class', 'country')
-            .attr('d', d3.pathGenerator)
+            .attr('d', pathGenerator)
 })


### PR DESCRIPTION
## Summary
- update map.js to use the `pathGenerator` variable instead of `d3.pathGenerator`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e34de6fb4832e882d9b1d4cc93cc4