### PR TITLE
Fix 'Infrastructure' typo in story map title

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,7 +96,7 @@ var config = {
     usecases: [
       {
         id: "use-case-0",
-        title:"Story Map: How the Infrasturcture Bill Comes Up Short on Replacing Lead Water Pipes",
+        title:"Story Map: How the Infrastructure Bill Comes Up Short on Replacing Lead Water Pipes",
         description:"In this story map, I use data from across the US to show how states in the Midwest need more from the 2021 Infrastructure Bill.",
         link:"https://blueconduit.com/funding-lead-pipe-removal"
       },


### PR DESCRIPTION
## Summary
- correct 'Infrasturcture' spelling in config.js so the story map title reads 'Infrastructure'

## Testing
- `grep -in 'Infrastructure Bill' config.js`


------
https://chatgpt.com/codex/tasks/task_e_684e34f16ef4832eabc4589407856833